### PR TITLE
Updated code to remove errors / warnings and fix compatibility issues…

### DIFF
--- a/custom_components/rika_firenet/__init__.py
+++ b/custom_components/rika_firenet/__init__.py
@@ -57,9 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             coordinator.platforms.append(platform)
-            hass.async_add_job(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
-            )
+            await hass.config_entries.async_forward_entry_setup(entry, platform)
 
     entry.add_update_listener(async_reload_entry)
 

--- a/custom_components/rika_firenet/climate.py
+++ b/custom_components/rika_firenet/climate.py
@@ -1,11 +1,9 @@
 import logging
 
 from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import (HVAC_MODE_AUTO,
-                                                    HVAC_MODE_HEAT,
-                                                    HVAC_MODE_OFF,
-                                                    SUPPORT_TARGET_TEMPERATURE)
-from homeassistant.const import (ATTR_TEMPERATURE, TEMP_CELSIUS)
+from homeassistant.components.climate.const import HVACMode, ClimateEntityFeature
+
+from homeassistant.const import (ATTR_TEMPERATURE, UnitOfTemperature)
 
 from .const import (DOMAIN, SUPPORT_PRESET)
 from .core import RikaFirenetCoordinator
@@ -13,12 +11,12 @@ from .entity import RikaFirenetEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE  # | SUPPORT_PRESET_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE  # | SUPPORT_PRESET_MODE
 
 MIN_TEMP = 16
 MAX_TEMP = 30
 
-HVAC_MODES = [HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF]
+HVAC_MODES = [HVACMode.AUTO, HVACMode.HEAT, HVACMode.OFF]
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -90,7 +88,7 @@ class RikaFirenetStoveClimate(RikaFirenetEntity, ClimateEntity):
 
     @property
     def temperature_unit(self):
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     def set_temperature(self, **kwargs):
         temperature = int(kwargs.get(ATTR_TEMPERATURE))

--- a/custom_components/rika_firenet/core.py
+++ b/custom_components/rika_firenet/core.py
@@ -4,10 +4,8 @@ from datetime import datetime, timedelta
 
 import requests
 from bs4 import BeautifulSoup
-from homeassistant.components.climate.const import (HVAC_MODE_AUTO,
-                                                    HVAC_MODE_HEAT,
-                                                    HVAC_MODE_OFF, PRESET_AWAY,
-                                                    PRESET_HOME)
+from homeassistant.components.climate.const import HVACMode, PRESET_AWAY, PRESET_HOME
+
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from .const import DOMAIN
 
@@ -315,22 +313,22 @@ class RikaFirenetStove:
 
     def get_hvac_mode(self):
         if not self.is_stove_on():
-            return HVAC_MODE_OFF
+            return HVACMode.OFF
 
-        if self.get_stove_operation_mode() is 0:
-            return HVAC_MODE_HEAT
+        if self.get_stove_operation_mode() == 0:
+            return HVACMode.HEAT
 
         if not self.is_heating_times_active_for_comfort():
-            return HVAC_MODE_HEAT
+            return HVACMode.HEAT
 
-        return HVAC_MODE_AUTO
+        return HVACMode.AUTO
 
     def set_hvac_mode(self, hvac_mode):
-        if hvac_mode == HVAC_MODE_OFF:
+        if hvac_mode == HVACMode.OFF:
             self.turn_off()
-        elif hvac_mode == HVAC_MODE_AUTO:
+        elif hvac_mode == HVACMode.AUTO:
             self.set_heating_times_active_for_comfort(True)
-        elif hvac_mode == HVAC_MODE_HEAT:
+        elif hvac_mode == HVACMode.HEAT:
             self.set_heating_times_active_for_comfort(False)
 
     def set_heating_times_active_for_comfort(self, active):

--- a/custom_components/rika_firenet/sensor.py
+++ b/custom_components/rika_firenet/sensor.py
@@ -1,6 +1,10 @@
 import logging
 
-from homeassistant.const import TEMP_CELSIUS, TIME_HOURS, MASS_KILOGRAMS, PERCENTAGE
+from homeassistant.const import UnitOfMass
+from homeassistant.const import UnitOfTemperature
+from homeassistant.const import PERCENTAGE
+from homeassistant.const import UnitOfTime
+
 from .entity import RikaFirenetEntity
 
 from .const import (
@@ -76,11 +80,11 @@ class RikaFirenetStoveSensor(RikaFirenetEntity):
     @property
     def unit_of_measurement(self):
         if "temperature" in self._sensor or "thermostat" in self._sensor:
-            return TEMP_CELSIUS
+            return UnitOfTemperature.CELSIUS
         elif self._sensor == "stove consumption":
-            return MASS_KILOGRAMS
+            return UnitOfMass.KILOGRAMS
         elif self._sensor == "stove runtime":
-            return TIME_HOURS
+            return UnitOfTime.HOURS
         elif self._sensor == "heating power":
             return PERCENTAGE
 


### PR DESCRIPTION
The integration stopped working with HASS 2025.2 due to depreciated constants.

I used chatGPT to help me find the up-to-date constants, and to fix a warning. 

I've tested it for ~24h on my setup.

Hope this can help others get their Rike Firenet integration working again with HASS 2025